### PR TITLE
ci: bump actions for deprecation of Node 20

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -42,13 +42,13 @@ jobs:
           GLOG_v: ${{ inputs.tsurugi_loglevel || 30 }}
     steps:
       - name: Setup_Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '21'
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Assemble
         run: |
@@ -59,7 +59,7 @@ jobs:
           ./gradlew check -Pdbtest.endpoint=${{ env.DBTEST_ENDPOINT }} --continue --warning-mode all
 
       - name: Verify
-        uses: project-tsurugi/tsurugi-annotations-action@v1
+        uses: project-tsurugi/tsurugi-annotations-action@v2
         if: always()
         with:
           junit_input: '**/build/test-results/**/TEST-*.xml'
@@ -67,7 +67,7 @@ jobs:
           checkstyle_input: '**/build/reports/checkstyle/main.xml'
 
       - name: Upload_ShadowJar
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: tsurugi-mcp-server-all.jar
           path: build/libs/tsurugi-mcp-server-all.jar

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -17,13 +17,13 @@ jobs:
 
     steps:
       - name: Setup_Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '21'
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create_Release
         if: contains(github.ref, '/tags/')


### PR DESCRIPTION
This pull request updates CI workflow dependencies to the latest versions of key GitHub Actions in preparation for the upcoming removal of Node 20 from GitHub Actions runners.
- https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/